### PR TITLE
NKS-2823 Add metadata to reservations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module go.universe.tf/metallb
 go 1.13
 
 require (
-	github.com/NetApp/nks-on-prem-ipam v0.1.4
+	github.com/NetApp/nks-on-prem-ipam v0.1.5
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 // indirect
 	github.com/eapache/channels v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/NetApp/nks-on-prem-ipam v0.1.4 h1:tQ/+BiRyLp7ns9tf/95EPSdAdrA+0XQTMCa6UknCWvk=
 github.com/NetApp/nks-on-prem-ipam v0.1.4/go.mod h1:ZfJJsukCxUTPVF4RnekFnVMz27x8SuU4YlD2jaqCKSU=
+github.com/NetApp/nks-on-prem-ipam v0.1.5 h1:l6BlckNPq+4DrP2xyceM7g4EqUY558JuiuQreZfI2vo=
+github.com/NetApp/nks-on-prem-ipam v0.1.5/go.mod h1:ZfJJsukCxUTPVF4RnekFnVMz27x8SuU4YlD2jaqCKSU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6 h1:uZuxRZCz65cG1o6K/xUqImNcYKtmk9ylqaH0itMSvzA=

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -6,12 +6,18 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"os"
 	"strings"
 
 	"go.universe.tf/metallb/internal/config"
 
 	"github.com/NetApp/nks-on-prem-ipam/pkg/ipam"
 	"github.com/mikioh/ipaddr"
+)
+
+const (
+	clusterIDEnvVariable = "CLUSTERID"
+	clusterIDMetaDataKey = "nks.netapp.io/clusterid"
 )
 
 // An Allocator tracks IP address pools and allocates addresses from them.
@@ -254,7 +260,9 @@ func (a *Allocator) AllocateFromPool(svc string, isIPv6 bool, poolName string, p
 }
 
 func (a *Allocator) allocateFromDynamicPool(pool *config.Pool, isIPv6 bool, svc string, ports []Port, sharingKey string, backendKey string, poolName string) (net.IP, error) {
-	res, err := pool.IPAM.ReserveIPs(ipam.NetworkType(poolName), ipam.IPv4, 1, nil)
+	metaData := reservationMetaData()
+
+	res, err := pool.IPAM.ReserveIPs(ipam.NetworkType(poolName), ipam.IPv4, 1, nil, metaData)
 	if err != nil {
 		return nil, fmt.Errorf("unable to reserve IPs from pool %q, %w", poolName, err)
 	}
@@ -475,4 +483,17 @@ func randomMAC() (string, error) {
 	buf[0] |= 2
 	mac := fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", buf[0], buf[1], buf[2], buf[3], buf[4], buf[5])
 	return mac, nil
+}
+
+func reservationMetaData() map[string]string {
+	clusterID := getClusterID()
+
+	return map[string]string{
+		clusterIDMetaDataKey: clusterID,
+	}
+}
+
+func getClusterID() string {
+	clusterID := os.Getenv(clusterIDEnvVariable)
+	return clusterID
 }

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -16,8 +16,16 @@ import (
 )
 
 const (
-	clusterIDEnvVariable = "CLUSTERID"
-	clusterIDMetaDataKey = "nks.netapp.io/clusterid"
+	workspaceIDEnvVariable = "WORKSPACE_ID"
+	instanceIDEnvVariable  = "INSTANCE_ID"
+	clusterIDEnvVariable   = "CLUSTER_ID"
+
+	workspaceIDMetaDataKey     = "nks.netapp.io/workspace"
+	instanceIDMetaDataKey      = "nks.netapp.io/instanceid"
+	clusterIDMetaDataKey       = "nks.netapp.io/cluster"
+	reservationTypeMetaDataKey = "nks.netapp.io/reservationtype"
+
+	reservationTypeMetaDataValue = "loadbalancer"
 )
 
 // An Allocator tracks IP address pools and allocates addresses from them.
@@ -486,14 +494,19 @@ func randomMAC() (string, error) {
 }
 
 func reservationMetaData() map[string]string {
-	clusterID := getClusterID()
+	workspaceID, instanceID, clusterID := clusterInfo()
 
 	return map[string]string{
-		clusterIDMetaDataKey: clusterID,
+		workspaceIDMetaDataKey:     workspaceID,
+		instanceIDMetaDataKey:      instanceID,
+		clusterIDMetaDataKey:       clusterID,
+		reservationTypeMetaDataKey: reservationTypeMetaDataValue,
 	}
 }
 
-func getClusterID() string {
+func clusterInfo() (string, string, string) {
+	workspaceID := os.Getenv(workspaceIDEnvVariable)
+	instanceID := os.Getenv(instanceIDEnvVariable)
 	clusterID := os.Getenv(clusterIDEnvVariable)
-	return clusterID
+	return workspaceID, instanceID, clusterID
 }

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -1415,6 +1416,40 @@ func TestPoolCount(t *testing.T) {
 			assert.Equalf(tt, test.want, got, "%q: wrong pool count, want %d, got %d", test.desc, test.want, got)
 		})
 	}
+}
+
+func TestReservationMetaData(t *testing.T) {
+	t.Run("WhenNoEnvVariableSet", func(tt *testing.T) {
+		metaData := reservationMetaData()
+		assert.Empty(tt, metaData[clusterIDMetaDataKey])
+	})
+
+	t.Run("WhenEnvVariableSet", func(tt *testing.T) {
+		randomClusterID := "awd12e78wa"
+		os.Setenv(clusterIDEnvVariable, randomClusterID)
+
+		metaData := reservationMetaData()
+		assert.Equal(tt, randomClusterID, metaData[clusterIDMetaDataKey])
+
+		os.Clearenv()
+	})
+}
+
+func TestGetClusterID(t *testing.T) {
+	t.Run("WhenNoEnvVariableSet", func(tt *testing.T) {
+		clusterID := getClusterID()
+		assert.Empty(tt, clusterID)
+	})
+
+	t.Run("WhenEnvVariableSet", func(tt *testing.T) {
+		randomClusterID := "awd12e78wa"
+		os.Setenv(clusterIDEnvVariable, randomClusterID)
+
+		clusterID := getClusterID()
+		assert.Equal(tt, randomClusterID, clusterID)
+
+		os.Clearenv()
+	})
 }
 
 // Some helpers

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -1425,11 +1425,22 @@ func TestReservationMetaData(t *testing.T) {
 	})
 
 	t.Run("WhenEnvVariableSet", func(tt *testing.T) {
-		randomClusterID := "awd12e78wa"
+		randomWorkspaceID := "workspace123"
+		os.Setenv(workspaceIDEnvVariable, randomWorkspaceID)
+		randomInstanceID := "instance123"
+		os.Setenv(instanceIDEnvVariable, randomInstanceID)
+		randomClusterID := "cluster123"
 		os.Setenv(clusterIDEnvVariable, randomClusterID)
 
+		expectedMetaData := map[string]string{
+			workspaceIDMetaDataKey:     randomWorkspaceID,
+			instanceIDMetaDataKey:      randomInstanceID,
+			clusterIDMetaDataKey:       randomClusterID,
+			reservationTypeMetaDataKey: reservationTypeMetaDataValue,
+		}
+
 		metaData := reservationMetaData()
-		assert.Equal(tt, randomClusterID, metaData[clusterIDMetaDataKey])
+		assert.Equal(tt, expectedMetaData, metaData)
 
 		os.Clearenv()
 	})
@@ -1437,15 +1448,23 @@ func TestReservationMetaData(t *testing.T) {
 
 func TestGetClusterID(t *testing.T) {
 	t.Run("WhenNoEnvVariableSet", func(tt *testing.T) {
-		clusterID := getClusterID()
+		workspaceID, instanceID, clusterID := clusterInfo()
+		assert.Empty(tt, workspaceID)
+		assert.Empty(tt, instanceID)
 		assert.Empty(tt, clusterID)
 	})
 
 	t.Run("WhenEnvVariableSet", func(tt *testing.T) {
-		randomClusterID := "awd12e78wa"
+		randomWorkspaceID := "workspace123"
+		os.Setenv(workspaceIDEnvVariable, randomWorkspaceID)
+		randomInstanceID := "instance123"
+		os.Setenv(instanceIDEnvVariable, randomInstanceID)
+		randomClusterID := "cluster123"
 		os.Setenv(clusterIDEnvVariable, randomClusterID)
 
-		clusterID := getClusterID()
+		workspaceID, instanceID, clusterID := clusterInfo()
+		assert.Equal(tt, randomWorkspaceID, workspaceID)
+		assert.Equal(tt, randomInstanceID, instanceID)
 		assert.Equal(tt, randomClusterID, clusterID)
 
 		os.Clearenv()


### PR DESCRIPTION
The environment variable is set when QMR deploys MetalLB. We use the environment variable to get the clusterID and attach it to the reservation request.